### PR TITLE
Help the user understand why HTTP fails

### DIFF
--- a/lib/HTTP/Tiny.pm
+++ b/lib/HTTP/Tiny.pm
@@ -1944,7 +1944,7 @@ L<HTTP::Tiny::UA>.
 * L<IO::Socket::IP> - Required for IPv6 support
 * L<IO::Socket::SSL> - Required for SSL support
 * L<LWP::UserAgent> - If HTTP::Tiny isn't enough for you, this is the "standard" way to do things
-* L<Mozilla::CA> - Validate SSL certificates when you don't have another source of a Certificate Authority cert
+* L<Mozilla::CA> - Validate SSL certificates when you don´t have another source of trusted Certificate Authority certificates
 * L<Net::SSLeay> - Required for SSL support
 
 =cut

--- a/lib/HTTP/Tiny.pm
+++ b/lib/HTTP/Tiny.pm
@@ -1944,7 +1944,7 @@ L<HTTP::Tiny::UA>.
 * L<IO::Socket::IP> - Required for IPv6 support
 * L<IO::Socket::SSL> - Required for SSL support
 * L<LWP::UserAgent> - If HTTP::Tiny isn't enough for you, this is the "standard" way to do things
-* L<Mozilla::CA> - Required if you want to validate SSL certificates
+* L<Mozilla::CA> - Validate SSL certificates when you don't have another source of a Certificate Authority cert
 * L<Net::SSLeay> - Required for SSL support
 
 =cut

--- a/lib/HTTP/Tiny.pm
+++ b/lib/HTTP/Tiny.pm
@@ -1795,11 +1795,11 @@ attacks|http://en.wikipedia.org/wiki/Machine-in-the-middle_attack>.
 Certificate verification requires a file containing trusted CA certificates.
 
 First, HTTP::Tiny looks in the SSL option C<SSL_ca_file>. If that has a defined
-value, HTT::Tiny uses that. If the file is not readable, HTTP::Tiny fails and does
+value, HTTP::Tiny uses that. If the file is not readable, HTTP::Tiny fails and does
 not look further.
 
 If the SSL option C<SSL_ca_file> is not defined, HTTP::Tiny looks at the environment
-variable C<SSL_CERT_FILE>. If that is defined but the filename is not readable, 
+variable C<SSL_CERT_FILE>. If that is defined but the filename is not readable,
 HTTP::Tiny fails and does not look further.
 
 If the L<Mozilla::CA> module is installed, HTTP::Tiny will use the CA file

--- a/lib/HTTP/Tiny.pm
+++ b/lib/HTTP/Tiny.pm
@@ -1647,9 +1647,9 @@ sub _find_CA_file {
       ? [ 'SSL_options->{SSL_ca_file}', $self->{SSL_options}->{SSL_ca_file} ]
       : [ 'SSL_CERT_FILE', $ENV{SSL_CERT_FILE} ];
 
-    if ( defined $ca_file[1] ) {
-        unless ( -r $ca_file[1] ) {
-            die qq/'$ca_file' from $ca_file[0] not found or not readable\n/;
+    if ( defined $ca_file->[1] ) {
+        unless ( -r $ca_file->[1] ) {
+            die qq/'$ca_file' from $ca_file->[0] not found or not readable\n/;
         }
         return $ca_file;
     }

--- a/lib/HTTP/Tiny.pm
+++ b/lib/HTTP/Tiny.pm
@@ -65,7 +65,7 @@ attributes are modified via accessor, or if the process ID or thread ID change,
 the persistent connection will be dropped.  If you want persistent connections
 across multiple destinations, use multiple HTTP::Tiny objects.
 
-See L</SSL SUPPORT> for more on the C<verify_SSL> and C<SSL_options> attributes.
+See L</TLS/SSL SUPPORT> for more on the C<verify_SSL> and C<SSL_options> attributes.
 
 =cut
 

--- a/lib/HTTP/Tiny.pm
+++ b/lib/HTTP/Tiny.pm
@@ -1644,14 +1644,14 @@ sub _find_CA_file {
 
     my $ca_file =
       defined( $self->{SSL_options}->{SSL_ca_file} )
-      ? [ 'SSL_options->{SSL_ca_file}', $self->{SSL_options}->{SSL_ca_file} ]
-      : [ 'SSL_CERT_FILE', $ENV{SSL_CERT_FILE} ];
+      ? { source => 'SSL_options->{SSL_ca_file}', file => $self->{SSL_options}->{SSL_ca_file} }
+      : { source => 'SSL_CERT_FILE',              file => $ENV{SSL_CERT_FILE} };
 
-    if ( defined $ca_file->[1] ) {
-        unless ( -r $ca_file->[1] ) {
-            die qq/'$ca_file' from $ca_file->[0] not found or not readable\n/;
+    if ( defined $ca_file->{file} ) {
+        unless ( -r $ca_file->{file} ) {
+            die qq/'$ca_file->{file}' from $ca_file->{source} not found or not readable\n/;
         }
-        return $ca_file;
+        return $ca_file->{file};
     }
 
     local @INC = @INC;


### PR DESCRIPTION
I ran into a hiccup where something using HTTP::Tiny found a wrong SSL_CERT_FILE environment variable I had. After setting up a new machine with the latest OpenSSL, that file ended up under a different prefix without updating the environment. 

HTTP::Tiny can do more to track down this sort of error.

First, in the docs that lay out how HTTP::Tiny finds the cert file, it missed the first step (SSL_options), and also didn't say that a defined but missing SSL_CERT_FILE would stop the process. I fixed that.

I also improved the error message a little so people will know in which step HTTP::Tiny failed.

I don't particularly care about how I typed it out, so change it as appropriate for whatever other concerns you have.

Some previous threads (chansen/p5-http-tiny#151, chansen/p5-http-tiny#152, metacpan/metacpan-client#117, metacpan/metacpan-client#82)