### PR TITLE
Run tests in GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: test
+on:
+  push:
+    branches:
+      - '*'
+    tags-ignore:
+      - '*'
+  pull_request:
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        perl: [ "5.22", "5.24", "5.26", "5.28", "5.32", "5.34", "5.36", "5.38", "5.40" ]
+    name: Perl ${{ matrix.perl }} on ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up perl
+        uses: shogo82148/actions-setup-perl@v1
+        with:
+          perl-version: ${{ matrix.perl }}
+      - run: perl -V
+      - run: prove -lv t


### PR DESCRIPTION
Adds Github actions test for perl 5.22 - 5.40 on Linux, macOS and Windows

AUTOMATED_TESTING is purposefully not set to 1 to prevent depending on network tests