### PR TITLE
fix string comparisons with $] to use numeric comparison instead

### DIFF
--- a/lib/HTTP/Tiny.pm
+++ b/lib/HTTP/Tiny.pm
@@ -865,7 +865,7 @@ sub _prepare_headers_and_cb {
         }
         elsif ( length $args->{content} ) {
             my $content = $args->{content};
-            if ( $] ge '5.008' ) {
+            if ( "$]" >= 5.008 ) {
                 utf8::downgrade($content, 1)
                     or die(qq/Wide character in request message body\n/);
             }
@@ -1032,7 +1032,7 @@ my $unsafe_char = qr/[^A-Za-z0-9\-\._~]/;
 sub _uri_escape {
     my ($self, $str) = @_;
     return "" if !defined $str;
-    if ( $] ge '5.008' ) {
+    if ( "$]" >= 5.008 ) {
         utf8::encode($str);
     }
     else {
@@ -1189,7 +1189,7 @@ sub write {
     @_ == 2 || die(q/Usage: $handle->write(buf)/ . "\n");
     my ($self, $buf) = @_;
 
-    if ( $] ge '5.008' ) {
+    if ( "$]" >= 5.008 ) {
         utf8::downgrade($buf, 1)
             or die(qq/Wide character in write()\n/);
     }
@@ -1474,7 +1474,7 @@ sub write_content_body {
         defined $data && length $data
           or last;
 
-        if ( $] ge '5.008' ) {
+        if ( "$]" >= 5.008 ) {
             utf8::downgrade($data, 1)
                 or die(qq/Wide character in write_content()\n/);
         }
@@ -1521,7 +1521,7 @@ sub write_chunked_body {
         defined $data && length $data
           or last;
 
-        if ( $] ge '5.008' ) {
+        if ( "$]" >= 5.008 ) {
             utf8::downgrade($data, 1)
                 or die(qq/Wide character in write_chunked_body()\n/);
         }


### PR DESCRIPTION
The fix follows Zefram's suggestion from
https://www.nntp.perl.org/group/perl.perl5.porters/2012/05/msg186846.html

> On older perls, however, $] had a numeric value that was built up using
> floating-point arithmetic, such as 5+0.006+0.000002.  This would not
> necessarily match the conversion of the complete value from string form
> [perl #72210].  You can work around that by explicitly stringifying
> $] (which produces a correct string) and having *that* numify (to a
> correctly-converted floating point value) for comparison.  I cultivate
> the habit of always stringifying $] to work around this, regardless of
> the threshold where the bug was fixed.  So I'd write
>
>     use if "$]" >= 5.014, warnings => "non_unicode";


This ensures that the comparisons will still work when Perl's major version changes to anything greater than 9.