### PR TITLE
Update known CA trust store locations for newer RH-verse

### DIFF
--- a/lib/HTTP/Tiny.pm
+++ b/lib/HTTP/Tiny.pm
@@ -1665,14 +1665,15 @@ sub _find_CA {
     # src/crypto/x509/root_unix.go
     #
     foreach my $ca_bundle (
-        "/etc/ssl/certs/ca-certificates.crt",     # Debian/Ubuntu/Gentoo etc.
-        "/etc/pki/tls/certs/ca-bundle.crt",       # Fedora/RHEL
-        "/etc/ssl/ca-bundle.pem",                 # OpenSUSE
-        "/etc/openssl/certs/ca-certificates.crt", # NetBSD
-        "/etc/ssl/cert.pem",                      # OpenBSD
-        "/usr/local/share/certs/ca-root-nss.crt", # FreeBSD/DragonFly
-        "/etc/pki/tls/cacert.pem",                # OpenELEC
-        "/etc/certs/ca-certificates.crt",         # Solaris 11.2+
+        "/etc/ssl/certs/ca-certificates.crt",                   # Debian/Ubuntu/Gentoo etc.
+        "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",    # Fedora/RHEL 2013+
+        "/etc/pki/tls/certs/ca-bundle.crt",                     # Fedora/RHEL older
+        "/etc/ssl/ca-bundle.pem",                               # OpenSUSE
+        "/etc/openssl/certs/ca-certificates.crt",               # NetBSD
+        "/etc/ssl/cert.pem",                                    # OpenBSD
+        "/usr/local/share/certs/ca-root-nss.crt",               # FreeBSD/DragonFly
+        "/etc/pki/tls/cacert.pem",                              # OpenELEC
+        "/etc/certs/ca-certificates.crt",                       # Solaris 11.2+
     ) {
         return ( SSL_ca_file => $ca_bundle ) if -e $ca_bundle;
     }
@@ -1818,6 +1819,7 @@ a CA certificate file as a last resort:
 
 =for :list
 * /etc/ssl/certs/ca-certificates.crt
+* /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 * /etc/pki/tls/certs/ca-bundle.crt
 * /etc/ssl/ca-bundle.pem
 * /etc/openssl/certs/ca-certificates.crt


### PR DESCRIPTION
Since 2013, /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem has been a preferred canonical path for the Red Hat universe's trust bundle. With
https://fedoraproject.org/wiki/Changes/dropingOfCertPemFile , /etc/pki/tls/certs/ca-bundle.crt is being removed from Fedora 43 onwards.