### PR TITLE
Strip auth headers on cross-origin redirects

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,10 @@
 Release notes for HTTP-Tiny
 
 {{$NEXT}}
+    [CHANGED]
+
+    - Redirects are no longer automatically followed when going from https to http.
+      Use allow_downgrade to revert to the original behaviour.
 
 0.093     2026-05-11 17:18:12+02:00 Europe/Brussels (TRIAL RELEASE)
 

--- a/Changes
+++ b/Changes
@@ -1,7 +1,11 @@
 Release notes for HTTP-Tiny
 
 {{$NEXT}}
-    [CHANGED]
+    [!!! SECURITY !!!]
+
+    - Caller-supplied C<Authorization>, C<Cookie>, and C<Proxy-Authorization>
+      headers are now stripped on cross-origin redirects by default. Use
+      allow_credentialed_redirects to opt out.
 
     - Redirects are no longer automatically followed when going from https to http.
       Use allow_downgrade to revert to the original behaviour.

--- a/corpus/redirect-11.txt
+++ b/corpus/redirect-11.txt
@@ -1,0 +1,21 @@
+url
+  https://victim.example/secret
+expected
+  refused-redirect-body
+expected_url
+  https://victim.example/secret
+----------
+GET /secret HTTP/1.1
+Host: victim.example
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 302 Found
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 21
+Location: http://victim.example/secret
+
+refused-redirect-body
+

--- a/corpus/redirect-12.txt
+++ b/corpus/redirect-12.txt
@@ -1,0 +1,36 @@
+url
+  https://victim.example/secret
+expected
+  success
+expected_url
+  http://victim.example/secret
+new_args
+  allow_downgrade: 1
+----------
+GET /secret HTTP/1.1
+Host: victim.example
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 302 Found
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 8
+Location: http://victim.example/secret
+
+redirect
+
+----------
+GET /secret HTTP/1.1
+Host: victim.example
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 200 OK
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 7
+
+success

--- a/corpus/redirect-13.txt
+++ b/corpus/redirect-13.txt
@@ -1,0 +1,35 @@
+url
+  https://example.com/index.html
+expected
+  abcdefghijklmnopqrstuvwxyz1234567890abcdef
+expected_url
+  https://example.com/index2.html
+----------
+GET /index.html HTTP/1.1
+Host: example.com
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 302 Found
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/html
+Content-Length: 53
+Location: https://example.com/index2.html
+
+<a href="https://example.com/index2.html">redirect</a>
+
+----------
+GET /index2.html HTTP/1.1
+Host: example.com
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 200 OK
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 42
+
+abcdefghijklmnopqrstuvwxyz1234567890abcdef
+

--- a/corpus/redirect-14.txt
+++ b/corpus/redirect-14.txt
@@ -1,0 +1,35 @@
+url
+  http://example.com/index.html
+expected
+  abcdefghijklmnopqrstuvwxyz1234567890abcdef
+expected_url
+  https://example.com/index2.html
+----------
+GET /index.html HTTP/1.1
+Host: example.com
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 302 Found
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/html
+Content-Length: 53
+Location: https://example.com/index2.html
+
+<a href="https://example.com/index2.html">redirect</a>
+
+----------
+GET /index2.html HTTP/1.1
+Host: example.com
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 200 OK
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 42
+
+abcdefghijklmnopqrstuvwxyz1234567890abcdef
+

--- a/corpus/redirect-15.txt
+++ b/corpus/redirect-15.txt
@@ -1,0 +1,57 @@
+url
+  http://victim.example/secret
+expected
+  pwned
+expected_url
+  http://victim.example/back
+headers
+  Authorization: Bearer SECRET-TOKEN
+  Cookie: session=SECRET-SESSION
+  Proxy-Authorization: Basic c2VjcmV0OnNlY3JldA==
+----------
+GET /secret HTTP/1.1
+Host: victim.example
+Authorization: Bearer SECRET-TOKEN
+Cookie: session=SECRET-SESSION
+Proxy-Authorization: Basic c2VjcmV0OnNlY3JldA==
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 302 Found
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 8
+Location: http://attacker.example/loot
+
+redirect
+
+----------
+GET /loot HTTP/1.1
+Host: attacker.example
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 302 Found
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 8
+Location: http://victim.example/back
+
+redirect
+
+----------
+GET /back HTTP/1.1
+Host: victim.example
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 200 OK
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 5
+
+pwned
+

--- a/corpus/redirect-16.txt
+++ b/corpus/redirect-16.txt
@@ -1,0 +1,47 @@
+url
+  http://victim.example/secret
+expected
+  pwned
+expected_url
+  http://attacker.example/loot
+new_args
+  allow_credentialed_redirects: 1
+headers
+  Authorization: Bearer SECRET-TOKEN
+  Cookie: session=SECRET-SESSION
+  Proxy-Authorization: Basic c2VjcmV0OnNlY3JldA==
+----------
+GET /secret HTTP/1.1
+Host: victim.example
+Authorization: Bearer SECRET-TOKEN
+Cookie: session=SECRET-SESSION
+Proxy-Authorization: Basic c2VjcmV0OnNlY3JldA==
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 302 Found
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 8
+Location: http://attacker.example/loot
+
+redirect
+
+----------
+GET /loot HTTP/1.1
+Host: attacker.example
+Authorization: Bearer SECRET-TOKEN
+Cookie: session=SECRET-SESSION
+Proxy-Authorization: Basic c2VjcmV0OnNlY3JldA==
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 200 OK
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 5
+
+pwned
+

--- a/corpus/redirect-17.txt
+++ b/corpus/redirect-17.txt
@@ -1,0 +1,39 @@
+url
+  http://example.com/a
+expected
+  ok
+expected_url
+  http://example.com/b
+headers
+  Authorization: Bearer SECRET-TOKEN
+----------
+GET /a HTTP/1.1
+Host: example.com
+Authorization: Bearer SECRET-TOKEN
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 302 Found
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 8
+Location: http://example.com/b
+
+redirect
+
+----------
+GET /b HTTP/1.1
+Host: example.com
+Authorization: Bearer SECRET-TOKEN
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 200 OK
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 2
+
+ok
+

--- a/corpus/redirect-18.txt
+++ b/corpus/redirect-18.txt
@@ -1,0 +1,38 @@
+url
+  http://example.com:8080/foo
+expected
+  ok
+expected_url
+  http://example.com:8081/bar
+headers
+  Authorization: Bearer SECRET-TOKEN
+----------
+GET /foo HTTP/1.1
+Host: example.com:8080
+Authorization: Bearer SECRET-TOKEN
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 302 Found
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 8
+Location: http://example.com:8081/bar
+
+redirect
+
+----------
+GET /bar HTTP/1.1
+Host: example.com:8081
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 200 OK
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 2
+
+ok
+

--- a/corpus/redirect-19.txt
+++ b/corpus/redirect-19.txt
@@ -1,0 +1,40 @@
+url
+  https://example.com:8443/foo
+expected
+  ok
+expected_url
+  http://example.com:8443/foo
+new_args
+  allow_downgrade: 1
+headers
+  Authorization: Bearer SECRET-TOKEN
+----------
+GET /foo HTTP/1.1
+Host: example.com:8443
+Authorization: Bearer SECRET-TOKEN
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 302 Found
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 8
+Location: http://example.com:8443/foo
+
+redirect
+
+----------
+GET /foo HTTP/1.1
+Host: example.com:8443
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 200 OK
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 2
+
+ok
+

--- a/corpus/redirect-20.txt
+++ b/corpus/redirect-20.txt
@@ -1,0 +1,41 @@
+url
+  http://victim.example/submit
+method
+  POST
+expected
+  ok
+expected_url
+  http://attacker.example/loot
+headers
+  Authorization: Bearer SECRET-TOKEN
+----------
+POST /submit HTTP/1.1
+Host: victim.example
+Authorization: Bearer SECRET-TOKEN
+Connection: close
+Content-Length: 0
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 303 See Other
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 8
+Location: http://attacker.example/loot
+
+redirect
+
+----------
+GET /loot HTTP/1.1
+Host: attacker.example
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 200 OK
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 2
+
+ok
+

--- a/corpus/redirect-21.txt
+++ b/corpus/redirect-21.txt
@@ -1,0 +1,38 @@
+url
+  https://victim.example/x
+expected
+  pwned
+expected_url
+  https://attacker.example/loot
+headers
+  Authorization: Bearer TRUSTED-TOKEN
+----------
+GET /x HTTP/1.1
+Host: victim.example
+Authorization: Bearer TRUSTED-TOKEN
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 302 Found
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 8
+Location: //attacker.example/loot
+
+redirect
+
+----------
+GET /loot HTTP/1.1
+Host: attacker.example
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 200 OK
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 5
+
+pwned
+

--- a/corpus/redirect-22.txt
+++ b/corpus/redirect-22.txt
@@ -1,0 +1,40 @@
+url
+  http://example.com/login
+expected
+  ok
+expected_url
+  https://example.com/login
+headers
+  Authorization: Bearer SECRET-TOKEN
+  Cookie: session=SECRET-SESSION
+----------
+GET /login HTTP/1.1
+Host: example.com
+Authorization: Bearer SECRET-TOKEN
+Cookie: session=SECRET-SESSION
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 302 Found
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 8
+Location: https://example.com/login
+
+redirect
+
+----------
+GET /login HTTP/1.1
+Host: example.com
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 200 OK
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 2
+
+ok
+

--- a/corpus/redirect-23.txt
+++ b/corpus/redirect-23.txt
@@ -1,0 +1,36 @@
+url
+  https://user:pass@victim.example/secret
+expected
+  ok
+expected_url
+  https://attacker.example/loot
+----------
+GET /secret HTTP/1.1
+Host: victim.example
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+Authorization: Basic dXNlcjpwYXNz
+
+----------
+HTTP/1.1 302 Found
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 8
+Location: https://attacker.example/loot
+
+redirect
+
+----------
+GET /loot HTTP/1.1
+Host: attacker.example
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 200 OK
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 2
+
+ok
+

--- a/corpus/redirect-24.txt
+++ b/corpus/redirect-24.txt
@@ -1,0 +1,38 @@
+url
+  https://user:pass@victim.example/secret
+expected
+  ok
+expected_url
+  https://attacker.example/loot
+new_args
+  allow_credentialed_redirects: 1
+----------
+GET /secret HTTP/1.1
+Host: victim.example
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+Authorization: Basic dXNlcjpwYXNz
+
+----------
+HTTP/1.1 302 Found
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 8
+Location: https://attacker.example/loot
+
+redirect
+
+----------
+GET /loot HTTP/1.1
+Host: attacker.example
+Connection: close
+User-Agent: HTTP-Tiny/VERSION
+
+----------
+HTTP/1.1 200 OK
+Date: Thu, 03 Feb 1994 00:00:00 GMT
+Content-Type: text/plain
+Content-Length: 2
+
+ok
+

--- a/lib/HTTP/Tiny.pm
+++ b/lib/HTTP/Tiny.pm
@@ -18,6 +18,12 @@ This constructor returns a new HTTP::Tiny object.  Valid attributes include:
 * C<agent> — A user-agent string (defaults to 'HTTP-Tiny/$VERSION'). If
   C<agent> — ends in a space character, the default user-agent string is
   appended.
+* C<allow_credentialed_redirects> - If a 3xx redirects to a different scheme,
+  host or port, by default HTTP::Tiny will strip away caller-supplied
+  C<Authorization>, C<Cookie> and C<Proxy-Authorization> headers from the
+  redirected request and from all subsequent requests in the chain. Set this to a
+  true value to revert to the legacy behavior of forwarding those headers.
+  Default is C<false>.
 * C<allow_downgrade> — If a 3xx redirect changes the scheme from C<https> to
   plain C<http>, HTTP::Tiny will by default refuse to follow it, returning the
   3xx response. Set this to a true value to revert to the legacy behavior of
@@ -85,9 +91,9 @@ attributes.
 my @attributes;
 BEGIN {
     @attributes = qw(
-        allow_downgrade cookie_jar default_headers http_proxy https_proxy
-        keep_alive local_address max_redirect max_size proxy no_proxy
-        SSL_options verify_SSL
+        allow_credentialed_redirects allow_downgrade cookie_jar default_headers
+        http_proxy https_proxy keep_alive local_address max_redirect max_size
+        proxy no_proxy SSL_options verify_SSL
     );
     my %persist_ok = map {; $_ => 1 } qw(
         cookie_jar default_headers max_redirect max_size
@@ -368,8 +374,7 @@ Don't use C<get> when you really want C<GET>.  See L</LIMITATIONS> for
 how this applies to redirection.
 
 If the URL includes a "user:password" stanza, they will be used for Basic-style
-authorization headers.  (Authorization headers will not be included in a
-redirected request.) For example:
+authorization headers.  For example:
 
     $http->request('GET', 'http://Aladdin:open sesame@example.com/');
 
@@ -377,6 +382,10 @@ If the "user:password" stanza contains reserved characters, they must
 be percent-escaped:
 
     $http->request('GET', 'http://john%40example.com:password@example.com/');
+
+Caller-supplied C<Authorization>, C<Cookie> and C<Proxy-Authorization> headers
+are stripped on cross-origin redirects. See L</new>'s
+C<allow_credentialed_redirects> attribute to opt out.
 
 A hashref of options may be appended to modify the request.
 
@@ -462,6 +471,7 @@ contain 599, and the C<content> field will contain the text of the error.
 =cut
 
 my %idempotent = map { $_ => 1 } qw/GET HEAD PUT DELETE OPTIONS TRACE/;
+my %sensitive_headers = map { $_ => 1 } qw/authorization cookie proxy-authorization/;
 
 sub request {
     my ($self, $method, $url, $args) = @_;
@@ -846,6 +856,7 @@ sub _prepare_headers_and_cb {
     for ($self->{default_headers}, $args->{headers}) {
         next unless defined;
         while (my ($k, $v) = each %$_) {
+            next if $args->{_strip_credentials} && exists $sensitive_headers{lc $k};
             $request->{headers}{lc $k} = $v;
             $request->{header_case}{lc $k} = $k;
         }
@@ -976,9 +987,17 @@ sub _maybe_redirect {
         my $location = ($headers->{location} =~ /^\//)
             ? "$request->{scheme}://$request->{host_port}$headers->{location}"
             : $headers->{location} ;
-        my ($to_scheme) = $self->_split_url($location);
+        my ($to_scheme, $to_host, $to_port) = $self->_split_url($location);
         if (!$self->{allow_downgrade} && $request->{scheme} eq 'https' && $to_scheme eq 'http' ) {
             return;
+        }
+        if (
+            !$self->{allow_credentialed_redirects}
+            && (   $request->{scheme} ne $to_scheme
+                || $request->{host} ne $to_host
+                || $request->{port} ne $to_port )
+        ) {
+            $args->{_strip_credentials} = 1;
         }
 
         return (($status eq '303' ? 'GET' : $method), $location);
@@ -1776,6 +1795,7 @@ sub _ssl_args {
 =for Pod::Coverage
 SSL_options
 agent
+allow_credentialed_redirects
 allow_downgrade
 cookie_jar
 default_headers

--- a/lib/HTTP/Tiny.pm
+++ b/lib/HTTP/Tiny.pm
@@ -18,6 +18,10 @@ This constructor returns a new HTTP::Tiny object.  Valid attributes include:
 * C<agent> — A user-agent string (defaults to 'HTTP-Tiny/$VERSION'). If
   C<agent> — ends in a space character, the default user-agent string is
   appended.
+* C<allow_downgrade> — If a 3xx redirect changes the scheme from C<https> to
+  plain C<http>, HTTP::Tiny will by default refuse to follow it, returning the
+  3xx response. Set this to a true value to revert to the legacy behavior of
+  redirecting C<https> to C<http>. Default is C<false>.
 * C<cookie_jar> — An instance of L<HTTP::CookieJar> — or equivalent class
   that supports the C<add> and C<cookie_header> methods
 * C<default_headers> — A hashref of default headers to apply to requests
@@ -81,8 +85,8 @@ attributes.
 my @attributes;
 BEGIN {
     @attributes = qw(
-        cookie_jar default_headers http_proxy https_proxy keep_alive
-        local_address max_redirect max_size proxy no_proxy
+        allow_downgrade cookie_jar default_headers http_proxy https_proxy
+        keep_alive local_address max_redirect max_size proxy no_proxy
         SSL_options verify_SSL
     );
     my %persist_ok = map {; $_ => 1 } qw(
@@ -972,6 +976,11 @@ sub _maybe_redirect {
         my $location = ($headers->{location} =~ /^\//)
             ? "$request->{scheme}://$request->{host_port}$headers->{location}"
             : $headers->{location} ;
+        my ($to_scheme) = $self->_split_url($location);
+        if (!$self->{allow_downgrade} && $request->{scheme} eq 'https' && $to_scheme eq 'http' ) {
+            return;
+        }
+
         return (($status eq '303' ? 'GET' : $method), $location);
     }
     return;
@@ -1767,6 +1776,7 @@ sub _ssl_args {
 =for Pod::Coverage
 SSL_options
 agent
+allow_downgrade
 cookie_jar
 default_headers
 http_proxy

--- a/lib/HTTP/Tiny.pm
+++ b/lib/HTTP/Tiny.pm
@@ -984,9 +984,11 @@ sub _maybe_redirect {
         and $headers->{location}
         and @{$args->{_redirects}} < $self->{max_redirect}
     ) {
-        my $location = ($headers->{location} =~ /^\//)
+        my $location = $headers->{location} =~ m{^//}
+        ? "$request->{scheme}:$headers->{location}"
+        : $headers->{location} =~ m{^/}
             ? "$request->{scheme}://$request->{host_port}$headers->{location}"
-            : $headers->{location} ;
+            : $headers->{location};
         my ($to_scheme, $to_host, $to_port) = $self->_split_url($location);
         if (!$self->{allow_downgrade} && $request->{scheme} eq 'https' && $to_scheme eq 'http' ) {
             return;

--- a/t/001_api.t
+++ b/t/001_api.t
@@ -7,7 +7,7 @@ use Test::More tests => 2;
 use HTTP::Tiny;
 
 my @accessors = qw(
-  agent default_headers http_proxy https_proxy keep_alive local_address
+  agent allow_downgrade default_headers http_proxy https_proxy keep_alive local_address
   max_redirect max_size proxy no_proxy timeout SSL_options verify_SSL cookie_jar
 );
 my @methods   = qw(

--- a/t/001_api.t
+++ b/t/001_api.t
@@ -7,8 +7,9 @@ use Test::More tests => 2;
 use HTTP::Tiny;
 
 my @accessors = qw(
-  agent allow_downgrade default_headers http_proxy https_proxy keep_alive local_address
-  max_redirect max_size proxy no_proxy timeout SSL_options verify_SSL cookie_jar
+    agent allow_credentialed_redirects allow_downgrade default_headers http_proxy
+    https_proxy keep_alive local_address max_redirect max_size proxy no_proxy timeout
+    SSL_options verify_SSL cookie_jar
 );
 my @methods   = qw(
   new get head put post patch delete post_form request mirror www_form_urlencode can_ssl


### PR DESCRIPTION
- **refuse https to http redirects by default**
- **strip auth headers on cross-origin redirects**
- **Fix protocol-relative Location handling so it can't be used to bypass credential strip**
- **demonstrate that https upgrade now strips credentials**
